### PR TITLE
桌游搜索功能维护

### DIFF
--- a/apps/search.js
+++ b/apps/search.js
@@ -21,11 +21,11 @@ export class NewSearch extends plugin {
           fnc: 'help'
         },
         {
-          reg: '^#bgg搜索',
+          reg: '^#桌游搜索',
           fnc: 'bggSearch'
         },
         {
-          reg: '^#bgg排行$',
+          reg: '^#桌游排行$',
           fnc: 'bggRank'
         }
       ]
@@ -48,14 +48,14 @@ export class NewSearch extends plugin {
   }
 
   async bggSearch (e) {
-    let keyword = e.msg.replace(/#?bgg搜索/, '')
+    let keyword = e.msg.replace(/#?桌游搜索/, '')
     funApi.bgg(keyword)
       .then(res => e.reply(res))
       .catch(err => common.handleException(e, err))
   }
 
   async bggRank (e) {
-    let url = 'https://boardgamegeek.com/browse/boardgame'
-    e.reply([await puppeteer.Webpage({ url }), url])
+            let url = `https://boardgamegeek.com/browse/boardgame`;
+    e.reply([await puppeteer.Webpage({ url }), "目前BGG桌游排行榜如图，访问链接："+url])
   }
 }

--- a/model/api/funApi.js
+++ b/model/api/funApi.js
@@ -293,12 +293,16 @@ export default new class {
     } = scriptdata.item
     let avgweight = scriptdata.item.stats.avgweight.substring(0, 4)
     let OverallRank = scriptdata.item.rankinfo[0].rank
-    const gameName1 = JSON.parse(
-      bgg$("script[type='application/ld+json']").text()
-    ).name
-    const gameimg = JSON.parse(
-      bgg$("script[type='application/ld+json']").text()
-    ).image
+
+
+// 获取游戏英文名字
+const gameName1 = bgg$(`meta[property='og:title']`).attr('content');
+
+// 获取游戏图片URL
+const gameimgLink = bgg$(`link[rel='preload'][as='image']:eq(1)`).attr('href');
+
+// 游戏图片URL可能有多条，这里取第一条
+const gameimg = gameimgLink ? gameimgLink : null;
 
     logger.info(`游戏英文名字:${gameName1}`)
 


### PR DESCRIPTION
1、修改了funapi.js，现在能正确地从bgg网站获取游戏英文名及图片。
2、原#bgg搜索、#bgg排行指令修改为#桌游搜索、#桌游排行。