### PR TITLE
fix: 兼容非数字适配器用户 ID 的群禁言

### DIFF
--- a/apps/groupAdmin/groupAdmin.js
+++ b/apps/groupAdmin/groupAdmin.js
@@ -13,6 +13,20 @@ const noactivereg = new RegExp(`^#(查看|清理|获取)(${Numreg})个?(${TimeUn
 /** 我要自闭正则 */
 const Autisticreg = new RegExp(`^#?我要(自闭|禅定)(${Numreg})?个?(${TimeUnitReg})?$`, "i")
 
+/**
+ * 从标准 at 消息段提取适配器用户 ID
+ * @param {object} e 消息事件
+ * @returns {Array<string|number>} 用户 ID 列表
+ */
+function getAtUserIds(e) {
+  const selfIds = new Set([ e.self_id, e.bot?.uin ].filter(Boolean).map(String))
+  return e.message
+    .filter(item => item.type === "at" && item.is_you !== true && item.is_you !== "true")
+    .map(item => item.qq)
+    .filter(id => id !== undefined && id !== null && String(id).trim() !== "")
+    .filter(id => String(id) !== "all" && !selfIds.has(String(id)))
+}
+
 Ga.loadRedisMuteTask()
 
 export class GroupAdmin extends plugin {
@@ -104,13 +118,13 @@ export class GroupAdmin extends plugin {
 
   async muteMember(e) {
     if (!common.checkPermission(e, "admin", "admin")) return true
-    let qq = e.message.filter(item => item.type == "at").map(item => item.qq)
-    if (qq.length < 2) qq = qq[0] || e.msg.match(/#禁言\s?(\d+)/)?.[1]
+    const targets = getAtUserIds(e)
+    const userId = targets.length > 1 ? targets : targets[0] || e.msg.match(/#禁言\s?(\d+)/)?.[1]
     const time = translateChinaNum(e.msg.match(new RegExp(Numreg))?.[0])
     try {
       const res = await new Ga(e).muteMember(
         e.group_id,
-        qq,
+        userId,
         e.user_id,
         time,
         e.msg.match(new RegExp(TimeUnitReg))?.[0]
@@ -123,10 +137,10 @@ export class GroupAdmin extends plugin {
 
   async noMuteMember(e) {
     if (!common.checkPermission(e, "admin", "admin")) return true
-    let qq = e.message.filter(item => item.type == "at").map(item => item.qq)
-    if (qq.length < 2) qq = qq[0] || e.msg.match(/#解禁(\d+)/)?.[1]
+    const targets = getAtUserIds(e)
+    const userId = targets.length > 1 ? targets : targets[0] || e.msg.match(/#解禁(\d+)/)?.[1]
     try {
-      const res = await new Ga(e).muteMember(e.group_id, qq, e.user_id, 0)
+      const res = await new Ga(e).muteMember(e.group_id, userId, e.user_id, 0)
       e.reply(res)
     } catch (err) {
       common.handleException(e, err)

--- a/model/GroupAdmin.js
+++ b/model/GroupAdmin.js
@@ -392,8 +392,8 @@ export default class GroupAdmin {
    * @function muteMember
    * @description 将群成员禁言
    * @param {string|number} groupId - 群号
-   * @param {string|number|Array<number|string>} userId - QQ 号
-   * @param {string|number} executor - 执行操作的管理员 QQ 号
+   * @param {string|number|Array<number|string>} userId - 适配器用户 ID
+   * @param {string|number} executor - 执行操作的管理员用户 ID
    * @param {number} time - 禁言时长，默认为 5。如果传入 0 则表示解除禁言。
    * @param {string} unit - 禁言时长单位，默认为分钟
    * @returns {Promise<string>} - 返回操作结果
@@ -404,32 +404,31 @@ export default class GroupAdmin {
     const group = this.Bot.pickGroup(groupId, true)
 
     const muteSingleMember = async(id, isMore = false) => {
-      if (!(/\d{5,}/.test(id))) throw new ReplyError("❎ 请输入正确的QQ号")
+      if (id === undefined || id === null || String(id).trim() === "") throw new ReplyError("❎ 请输入正确的用户ID")
+      const normalizedId = String(id)
 
       // 判断是否为主人
-      if ((Config.masterQQ?.includes(Number(id) || String(id))) && time != 0) throw new ReplyError("❎ 该命令对主人无效")
+      if (Config.masterQQ?.some(value => String(value) === normalizedId) && time != 0) throw new ReplyError("❎ 该命令对主人无效")
 
-      const Member = group.pickMember(id)
+      const Member = group.pickMember?.(id)
       const Memberinfo = Member?.info || await Member?.getInfo?.()
-      // 判断是否有这个人
-      if (!Memberinfo) throw new ReplyError(`❎ 该群没有${isMore ? id : "这个人"}哦~`)
 
-      // 特殊处理
-      if (Memberinfo.role === "owner") throw new ReplyError("❎ 权限不足，该命令对群主无效")
+      // 仅在适配器提供成员资料时进行角色检查
+      if (Memberinfo?.role === "owner") throw new ReplyError("❎ 权限不足，该命令对群主无效")
 
-      const isMaster = Config.masterQQ?.includes(executor)
+      const isMaster = Config.masterQQ?.some(value => String(value) === String(executor))
 
-      if (Memberinfo.role === "admin") {
+      if (Memberinfo?.role === "admin") {
         if (!group.is_owner) throw new ReplyError("❎ 权限不足，需要群主权限")
         if (!isMaster) throw new ReplyError("❎ 只有主人才能对管理执行该命令")
       }
 
-      const isWhite = Config.groupAdmin.whiteQQ.includes(Number(id) || String(id))
+      const isWhite = Config.groupAdmin.whiteQQ.some(value => String(value) === normalizedId)
 
       if (isWhite && !isMaster && time != 0) throw new ReplyError(`❎ ${isMore ? id : "该用户"}为白名单成员，不可操作`)
 
       await group.muteMember(id, time * _unit)
-      const memberName = Memberinfo.card || Memberinfo.nickname || id
+      const memberName = Memberinfo?.card || Memberinfo?.nickname || id
       return memberName
     }
 


### PR DESCRIPTION
## 变更说明

- 群禁言/解禁命令从标准 `at.qq` 消息段提取适配器用户 ID，并过滤空值、`all` 和机器人自身
- 移除“用户 ID 必须是数字 QQ 号”的硬编码限制，将目标 ID 原样交给 `group.muteMember()`
- 主人和白名单 ID 统一按字符串比较，兼容数字和字符串配置
- 成员资料不可用时不再提前判定成员不存在；适配器能够提供资料时仍保留群主、管理员和白名单保护

## 背景

Yunzai 通用适配器的用户 ID 不保证为纯数字。部分平台使用 OpenID、UUID 或其他字符串 ID，但适配器仍可通过 `group.muteMember(userId, seconds)` 完成禁言。原有数字正则会在调用适配器前拦截这些合法 ID。

本修改只依赖标准消息段和通用群对象接口，不读取任何具体适配器的私有字段。

## 验证

- `pnpm exec eslint apps/groupAdmin/groupAdmin.js model/GroupAdmin.js`
- `node --check apps/groupAdmin/groupAdmin.js`
- `node --check model/GroupAdmin.js`
- `git diff --check`